### PR TITLE
feat: add webpack bundle analyzer to daily stats

### DIFF
--- a/extractors/bundle-size.ts
+++ b/extractors/bundle-size.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024-2025 Bjoern Kimminich & the OWASP Juice Shop contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { execSync } from 'child_process'
+import path from 'path'
+import fs from 'fs'
+
+const collectData = async (): Promise<void> => {
+  const juiceShopPath = process.env.JUICE_SHOP_PATH ?? path.resolve(__dirname, '../../../juice-shop')
+  const frontendPath = path.join(juiceShopPath, 'frontend')
+
+  if (!fs.existsSync(frontendPath)) {
+    console.log(`Juice Shop frontend not found at ${frontendPath}. Skipping bundle analysis.`)
+    return
+  }
+
+  console.log(`Generating Webpack Bundle Analysis for ${frontendPath}...`)
+
+  try {
+    // Install dependencies if needed (assuming CI environment might need it)
+    // using npm ci for clean install or npm install
+    console.log('Installing frontend dependencies...')
+    execSync('npm install', { cwd: frontendPath, stdio: 'inherit' })
+
+    // Build with stats-json
+    console.log('Building frontend with stats...')
+    // Use npx to use local ng CLI
+    execSync('npx ng build --stats-json', { cwd: frontendPath, stdio: 'inherit' })
+
+    // Find stats.json
+    // Angular usually outputs to dist/frontend/stats.json or just dist/stats.json
+    // We check common locations
+    const possibleStatsPaths = [
+      path.join(frontendPath, 'dist', 'frontend', 'stats.json'),
+      path.join(frontendPath, 'dist', 'juice-shop', 'stats.json'),
+      path.join(frontendPath, 'stats.json')
+    ]
+
+    const statsFile = possibleStatsPaths.find(p => fs.existsSync(p))
+
+    if (!statsFile) {
+      console.error('Could not find stats.json after build.')
+      return
+    }
+
+    // Generate static report
+    // Destination: we want it in juicy-statistics/public/stats.html so it gets picked up by express (or dist/public/stats.html)
+    // The 'collect' script runs from dist/, so process.cwd() is project root if run via npm run collect
+    // But better to be explicit.
+    
+    // We target 'dist/public' because that's where the running server looks for static files.
+    // We also might want to copy it to 'public' so it persists in source? 
+    // Usually 'public' is source. 'dist/public' is build artifact.
+    // If we generate into 'dist/public', it will be served.
+    
+    const outputDir = path.resolve('dist/public')
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true })
+    }
+    const reportPath = path.join(outputDir, 'stats.html')
+
+    console.log(`Generating report to ${reportPath}...`)
+    execSync(`npx webpack-bundle-analyzer "${statsFile}" -m static -r "${reportPath}" --no-open`, { stdio: 'inherit' })
+
+    console.log('Webpack Bundle Analysis generated successfully.')
+
+  } catch (error) {
+    console.error('Failed to generate bundle analysis:', error)
+  }
+}
+
+export { collectData }

--- a/extractors/collect.ts
+++ b/extractors/collect.ts
@@ -7,6 +7,15 @@ import * as docker from './docker'
 import * as github from './github'
 import * as npm from './npm'
 import * as spamReport from './spam-report'
+import * as bundleSize from './bundle-size'
+
+bundleSize.collectData().then(
+  () => {
+    console.log(`Sucessfully collected bundle-size stats for ${new Date().toString()}`)
+  }
+).catch((error) => {
+  console.log('Failed to collect bundle-size stats', error)
+})
 
 docker.collectData().then(
   () => {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -187,6 +187,16 @@
       </div>
     </div>
 
+    <div class="wide">
+      <div class="card">
+        <div class="card-body">
+          <h5 class="card-title">Frontend Bundle Size Analysis</h5>
+          <br/>
+          <iframe src="stats.html" width="100%" height="800px" style="border:none;"></iframe>
+        </div>
+      </div>
+    </div>
+
     <br /><br />
     <br /><br />
   </body>


### PR DESCRIPTION
solves #27
### Description
This PR addresses the issue of monitoring the frontend code size by integrating `webpack-bundle-analyzer` into the nightly stats collection.

It adds a new extractor that generates a visual treemap of the Juice Shop frontend bundle and embeds this report directly into the `juicy-statistics` dashboard.

### Changes
1.  **New Extractor (`extractors/bundle-size.ts`):** Checks for the Juice Shop frontend, installs dependencies, runs a build with stats, and generates a static `stats.html` report.
2.  **Updated Collector (`extractors/collect.ts`):** Added the bundle size extractor to the daily collection routine.
3.  **UI Update (`views/index.ejs`):** Added a new section at the bottom of the statistics page to display the interactive bundle analysis report via an iframe.

### How to Test
1.  Ensure a local copy of `juice-shop` exists as a sibling directory or set `JUICE_SHOP_PATH`.
2.  Run `npm run build`.
3.  Run `npm run collect` (This will take some time as it builds the frontend).
4.  Run `npm start`.
5.  Navigate to `http://localhost:3000` and scroll to the bottom to see the "Frontend Bundle Size Analysis" section.

### Screenshots
<img width="1897" height="966" alt="image" src="https://github.com/user-attachments/assets/6aca8aa3-c622-4a83-854a-f6bf08db8d36" />
